### PR TITLE
Enemy summoning Planetars

### DIFF
--- a/celestials/summon_spells/_baf/ca#fdeva.baf
+++ b/celestials/summon_spells/_baf/ca#fdeva.baf
@@ -32,6 +32,7 @@ END
 
 IF
 	LevelLT(LastSummonerOf(Myself),14)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -41,6 +42,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),14)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -50,6 +52,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),15)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -59,6 +62,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),16)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -68,6 +72,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),17)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -77,6 +82,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),18)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -86,6 +92,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),19)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN

--- a/celestials/summon_spells/_baf/ca#fplan.baf
+++ b/celestials/summon_spells/_baf/ca#fplan.baf
@@ -32,6 +32,7 @@ END
 
 IF
 	LevelLT(LastSummonerOf(Myself),18)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -41,6 +42,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),18)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -50,6 +52,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),19)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -59,6 +62,7 @@ END
 
 IF
 	LevelGT(LastSummonerOf(Myself),19)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN

--- a/celestials/summon_spells/_baf/ca#plan.baf
+++ b/celestials/summon_spells/_baf/ca#plan.baf
@@ -32,6 +32,7 @@ END
 
 IF
 	LevelLT(LastSummonerOf(Myself),18)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -41,6 +42,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),18)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -50,6 +52,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),19)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -59,6 +62,7 @@ END
 
 IF
 	LevelGT(LastSummonerOf(Myself),19)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN

--- a/celestials/summon_spells/_baf/ca#sdeva.baf
+++ b/celestials/summon_spells/_baf/ca#sdeva.baf
@@ -74,6 +74,7 @@ END
 
 IF
 	LevelLT(LastSummonerOf(Myself),14)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -83,6 +84,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),14)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -92,6 +94,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),15)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -101,6 +104,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),16)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -110,6 +114,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),17)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -119,6 +124,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),18)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -128,6 +134,7 @@ END
 
 IF
 	Level(LastSummonerOf(Myself),19)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN
@@ -137,6 +144,7 @@ END
 
 IF
 	LevelGT(LastSummonerOf(Myself),19)
+	Allegiance(LastSummonerOf(Myself),ALLY)
 	Global("Cast_CA_SUMMON_DEVA_PLANETAR","LOCALS",1)
 	!GlobalTimerNotExpired("Timer_CA_SUMMON_DEVA_PLANETAR","GLOBAL")
 THEN


### PR DESCRIPTION
In Vanilla game, enemies do not use Planetar/Deva summoning spells, but in modded game it is possible...

In the current version  https://github.com/Gibberlings3/PnP_Celestials/commit/ce42cba8798f5592f411f6fa035e47284c65d6da of Pnp Celestial, the first who summons a planetar block the second that can't cast the spell anymore. To avoid that, a trigger is added in scripts to filter enemies. They will now not be impact by summoning limit (like in Vanilla) and won't anymore block PC summons